### PR TITLE
Versioning and build.xml

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,3 @@
-#Wed Aug 03 06:36:16 CDT 2011
+#Tue Sep 06 10:09:05 BST 2011
 eclipse.preferences.version=1
 encoding//src/net/citizensnpcs/properties/SettingsManager.java=UTF-8

--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,7 @@
         </description>
       <!-- set global properties for this build -->
       <property name="src" location="src"/>
+	  <property name="bin" location="bin"/>
       <property name="build" location="build"/>
       <property name="core" location="build/core"/>
       <property name="blacksmith" location="build/blacksmith"/>
@@ -16,8 +17,9 @@
       <property name="libs" location="libs"/>
       <property name="releases" location="releases"/>
       <target name="init">
-        <!-- Create neccesary folders -->
+		<!-- Create neccesary folders -->
         <mkdir dir="${build}"/>
+		<mkdir dir="${bin}"/>
         <mkdir dir="${core}"/>
         <mkdir dir="${blacksmith}"/>
         <mkdir dir="${guard}"/>
@@ -25,13 +27,13 @@
         <mkdir dir="${quester}"/>
         <mkdir dir="${trader}"/>
         <mkdir dir="${wizard}"/>
-      	<mkdir dir="types"/>
+ 
        
       </target>
      
     <!-- Compile the code -->
      
-      <target name="core" depends="init" description="compile the source">
+      <target name="dist" depends="init" description="compile the source">
         <javac srcdir="${src}/core" destdir="${core}" debug="on" debuglevel="lines,vars,source" includeantruntime="false" encoding="Cp1252" >
                <classpath>
                 <pathelement path="${libs}"/>
@@ -46,6 +48,9 @@
                 <pathelement location="${libs}/BOSEconomy.jar"/>
                 </classpath>
         </javac>
+		<!-- Finish compiling the core early because the NPC types require the core! -->
+		<antcall target="distcore"/>
+		<antcall target="blacksmith"/>
       </target>
      
       <target name="blacksmith" depends="init" description="compile the source">
@@ -61,9 +66,11 @@
                 <pathelement location="${libs}/iCo5.jar"/>
                 <pathelement location="${libs}/iCo6.jar"/>
                 <pathelement location="${libs}/BOSEconomy.jar"/>
-                <pathelement location="Citizens.jar"/>
+                <pathelement location="${bin}/Citizens.jar"/>
                 </classpath>
         </javac>
+		<antcall target="distblacksmith"/>
+			<antcall target="guard"/>
       </target>
       <target name="guard" depends="init" description="compile the source">
         <javac srcdir="${src}/guard" destdir="${guard}" debug="on" debuglevel="lines,vars,source" includeantruntime="false" encoding="Cp1252" >
@@ -78,9 +85,11 @@
                 <pathelement location="${libs}/iCo5.jar"/>
                 <pathelement location="${libs}/iCo6.jar"/>
                 <pathelement location="${libs}/BOSEconomy.jar"/>
-                <pathelement location="Citizens.jar"/>
+                <pathelement location="${bin}/Citizens.jar"/>
                 </classpath>
         </javac>
+		<antcall target="distguard"/>
+			<antcall target="healer"/>
       </target>
       <target name="healer" depends="init" description="compile the source">
         <javac srcdir="${src}/healer" destdir="${healer}" debug="on" debuglevel="lines,vars,source" includeantruntime="false" encoding="Cp1252" >
@@ -95,9 +104,11 @@
                 <pathelement location="${libs}/iCo5.jar"/>
                 <pathelement location="${libs}/iCo6.jar"/>
                 <pathelement location="${libs}/BOSEconomy.jar"/>
-                <pathelement location="Citizens.jar"/>
+                <pathelement location="${bin}/Citizens.jar"/>
                 </classpath>
         </javac>
+		<antcall target="disthealer"/>
+			<antcall target="quester"/>
       </target>
       <target name="quester" depends="init" description="compile the source">
         <javac srcdir="${src}/quester" destdir="${quester}" debug="on" debuglevel="lines,vars,source" includeantruntime="false" encoding="Cp1252" >
@@ -112,9 +123,11 @@
                 <pathelement location="${libs}/iCo5.jar"/>
                 <pathelement location="${libs}/iCo6.jar"/>
                 <pathelement location="${libs}/BOSEconomy.jar"/>
-                <pathelement location="Citizens.jar"/>
+                <pathelement location="${bin}/Citizens.jar"/>
                 </classpath>
         </javac>
+		<antcall target="distquester"/>
+			<antcall target="trader"/>
       </target>
       <target name="trader" depends="init" description="compile the source">
         <javac srcdir="${src}/trader" destdir="${trader}" debug="on" debuglevel="lines,vars,source" includeantruntime="false" encoding="Cp1252" >
@@ -129,9 +142,11 @@
                 <pathelement location="${libs}/iCo5.jar"/>
                 <pathelement location="${libs}/iCo6.jar"/>
                 <pathelement location="${libs}/BOSEconomy.jar"/>
-                <pathelement location="Citizens.jar"/>
+                <pathelement location="${bin}/Citizens.jar"/>
                 </classpath>
         </javac>
+		<antcall target="disttrader"/>
+			 <antcall target="wizard"/>
       </target>
       <target name="wizard" depends="init" description="compile the source">
         <javac srcdir="${src}/wizard" destdir="${wizard}" debug="on" debuglevel="lines,vars,source" includeantruntime="false" encoding="Cp1252" >
@@ -146,51 +161,46 @@
                 <pathelement location="${libs}/iCo5.jar"/>
                 <pathelement location="${libs}/iCo6.jar"/>
                 <pathelement location="${libs}/BOSEconomy.jar"/>
-                <pathelement location="Citizens.jar"/>
+                <pathelement location="${bin}/Citizens.jar"/>
                 </classpath>
         </javac>
+				<antcall target="distwizard"/>
       </target>
      
       <!-- Generate the jars -->
-     
-      <target name="dist" depends="core" description="generate the distribution" >
-        <jar jarfile="Citizens.jar" basedir="${core}" encoding="Cp1252">
+      <target name="distcore" description="generate the distribution" >
+        <jar jarfile="${bin}/Citizens.jar" basedir="${core}" encoding="Cp1252">
         <zipfileset dir="." includes="*.yml"/>
         </jar>
-        <antcall target="distblacksmith"/>
+		
       </target>
-      <target name="distblacksmith" depends="blacksmith" description="generate the distribution" >
-        <jar jarfile="types/Blacksmith.jar" basedir="${blacksmith}" encoding="Cp1252">
+      <target name="distblacksmith" description="generate the distribution" >
+        <jar jarfile="${bin}/Blacksmith.jar" basedir="${blacksmith}" encoding="Cp1252">
         <zipfileset dir="${src}/blacksmith" includes="*.info"/>
         </jar>
-        <antcall target="distguard"/>
       </target>
-      <target name="distguard" depends="guard" description="generate the distribution" >
-        <jar jarfile="types/Guard.jar" basedir="${guard}" encoding="Cp1252">
+      <target name="distguard" description="generate the distribution" >
+        <jar jarfile="${bin}/Guard.jar" basedir="${guard}" encoding="Cp1252">
         <zipfileset dir="${src}/guard" includes="*.info"/>
         </jar>
-        <antcall target="disthealer"/>
       </target>
-      <target name="disthealer" depends="healer" description="generate the distribution" >
-        <jar jarfile="types/Healer.jar" basedir="${healer}" encoding="Cp1252">
+      <target name="disthealer" description="generate the distribution" >
+        <jar jarfile="${bin}/Healer.jar" basedir="${healer}" encoding="Cp1252">
         <zipfileset dir="${src}/healer" includes="*.info"/>
         </jar>
-        <antcall target="distquester"/>
       </target>
-      <target name="distquester" depends="quester" description="generate the distribution" >
-        <jar jarfile="types/Quester.jar" basedir="${quester}" encoding="Cp1252">
+      <target name="distquester" description="generate the distribution" >
+        <jar jarfile="${bin}/Quester.jar" basedir="${quester}" encoding="Cp1252">
         <zipfileset dir="${src}/quester" includes="*.info"/>
         </jar>
-        <antcall target="disttrader"/>
       </target>
-      <target name="disttrader" depends="trader" description="generate the distribution" >
-        <jar jarfile="types/Trader.jar" basedir="${trader}" encoding="Cp1252">
+      <target name="disttrader" description="generate the distribution" >
+        <jar jarfile="${bin}/Trader.jar" basedir="${trader}" encoding="Cp1252">
         <zipfileset dir="${src}/trader" includes="*.info"/>
         </jar>
-        <antcall target="distwizard"/>
       </target>
-      <target name="distwizard" depends="wizard" description="generate the distribution" >
-        <jar jarfile="types/Wizard.jar" basedir="${wizard}" encoding="Cp1252">
+      <target name="distwizard" description="generate the distribution" >
+        <jar jarfile="${bin}/Wizard.jar" basedir="${wizard}" encoding="Cp1252">
         <zipfileset dir="${src}/wizard" includes="*.info"/>
         </jar>
       </target>
@@ -200,6 +210,7 @@
         <!-- Delete the ${build} and ${dist} directory trees -->
         <delete dir="${build}"/>
         <delete dir="${dist}"/>
+		<delete dir="${bin}"/>
       </target>
      
     </project>

--- a/src/core/net/citizensnpcs/Citizens.java
+++ b/src/core/net/citizensnpcs/Citizens.java
@@ -235,7 +235,7 @@ public class Citizens extends JavaPlugin {
 					url.openStream()));
 			String line;
 			if ((line = reader.readLine()) != null) {
-				return "devBuild-" + Integer.parseInt(line); // Dunno why it is a string, then turned to an int, then back to a string, a more efficient way of trimming a string for excess whitespaces?
+				return "devBuild-" + line.trim();
 			}
 			reader.close();
 		} catch (Exception e) {
@@ -252,7 +252,7 @@ public class Citizens extends JavaPlugin {
 					url.openStream()));
 			String line;
 			if ((line = reader.readLine()) != null) {
-				return line.trim(); // Need to use trim because your version numbers contain letters and numbers.
+				return line.trim();
 			}
 			reader.close();
 		} catch (Exception e) {

--- a/src/core/net/citizensnpcs/Citizens.java
+++ b/src/core/net/citizensnpcs/Citizens.java
@@ -230,7 +230,7 @@ public class Citizens extends JavaPlugin {
 	public static String getLatestBuildVersion() // This returns the latest AVAILABLE devBuild, not the one in use!
 	{
 		try {
-			URL url = new URL("http://www.citizensnpcs.net/latest.php");
+			URL url = new URL("http://www.citizensnpcs.net/dev/latestdev.php");
 			BufferedReader reader = new BufferedReader(new InputStreamReader(
 					url.openStream()));
 			String line;
@@ -240,11 +240,28 @@ public class Citizens extends JavaPlugin {
 			reader.close();
 		} catch (Exception e) {
 			Messaging
-					.log("Could not connect to citizensnpcs.net to determine latest Jenkins build number.");
+					.log("Could not connect to citizensnpcs.net to determine latest development build number.");
 		}
 		return "devBuild-Unknown";
 	}
-	// Get the version of Citizens (dev-build or release) automagically.
+	public static String getLatestVersion() // This returns the latest AVAILABLE version, not the one in use!
+	{
+		try {
+			URL url = new URL("http://www.citizensnpcs.net/dev/latest.php");
+			BufferedReader reader = new BufferedReader(new InputStreamReader(
+					url.openStream()));
+			String line;
+			if ((line = reader.readLine()) != null) {
+				return "devBuild-" + Integer.parseInt(line);
+			}
+			reader.close();
+		} catch (Exception e) {
+			Messaging
+					.log("Could not connect to citizensnpcs.net to determine latest version.");
+		}
+		return "devBuild-Unknown";
+	}
+	// Get the CURRENT version of Citizens (dev-build or release) automagically.
 	public static String getVersion() {
 		return Version.VERSION;
 	}

--- a/src/core/net/citizensnpcs/Citizens.java
+++ b/src/core/net/citizensnpcs/Citizens.java
@@ -235,14 +235,14 @@ public class Citizens extends JavaPlugin {
 					url.openStream()));
 			String line;
 			if ((line = reader.readLine()) != null) {
-				return "devBuild-" + Integer.parseInt(line);
+				return "devBuild-" + Integer.parseInt(line); // Dunno why it is a string, then turned to an int, then back to a string, a more efficient way of trimming a string for excess whitespaces?
 			}
 			reader.close();
 		} catch (Exception e) {
 			Messaging
 					.log("Could not connect to citizensnpcs.net to determine latest development build number.");
 		}
-		return "devBuild-Unknown";
+		return getVersion();//Lets not trigger the update reminder if we can't find a version
 	}
 	public static String getLatestVersion() // This returns the latest AVAILABLE version, not the one in use!
 	{
@@ -252,14 +252,14 @@ public class Citizens extends JavaPlugin {
 					url.openStream()));
 			String line;
 			if ((line = reader.readLine()) != null) {
-				return "devBuild-" + Integer.parseInt(line);
+				return line.trim(); // Need to use trim because your version numbers contain letters and numbers.
 			}
 			reader.close();
 		} catch (Exception e) {
 			Messaging
 					.log("Could not connect to citizensnpcs.net to determine latest version.");
 		}
-		return "devBuild-Unknown";
+		return getVersion(); //Lets not trigger the update reminder if we can't find a version
 	}
 	// Get the CURRENT version of Citizens (dev-build or release) automagically.
 	public static String getVersion() {

--- a/src/core/net/citizensnpcs/Citizens.java
+++ b/src/core/net/citizensnpcs/Citizens.java
@@ -72,7 +72,7 @@ public class Citizens extends JavaPlugin {
 	public static List<String> loadedTypes = new ArrayList<String>();
 
 	// Set to false before release
-	public static boolean devBuild = true;
+	//public static boolean devBuild = true;// No longer required
 
 	@Override
 	public void onEnable() {
@@ -227,13 +227,8 @@ public class Citizens extends JavaPlugin {
 		return true;
 	}
 
-	// Get the release version of Citizens
-	public static String getReleaseVersion() {
-		return "1.1";
-	}
-
-	// Get the latest Jenkins build #
-	private static String getBuildVersion() {
+	public static String getLatestBuildVersion() // This returns the latest AVAILABLE devBuild, not the one in use!
+	{
 		try {
 			URL url = new URL("http://www.citizensnpcs.net/latest.php");
 			BufferedReader reader = new BufferedReader(new InputStreamReader(
@@ -249,13 +244,9 @@ public class Citizens extends JavaPlugin {
 		}
 		return "devBuild-Unknown";
 	}
-
-	// Get the version of Citizens (dev-build or release)
+	// Get the version of Citizens (dev-build or release) automagically.
 	public static String getVersion() {
-		if (devBuild) {
-			return getBuildVersion();
-		}
-		return getReleaseVersion();
+		return Version.VERSION;
 	}
 
 	private boolean handleMistake(CommandSender sender, String command,

--- a/src/core/net/citizensnpcs/Version.java
+++ b/src/core/net/citizensnpcs/Version.java
@@ -1,0 +1,5 @@
+package net.citizensnpcs;
+
+public final class Version {
+	public static String VERSION="1.1"; // This will be replaced by jenkins automagically when it builds, see http://www.citizensnpcs.net/dev/Version.php
+}

--- a/src/core/net/citizensnpcs/utils/ServerUtils.java
+++ b/src/core/net/citizensnpcs/utils/ServerUtils.java
@@ -30,14 +30,14 @@ public class ServerUtils {
 			if(Citizens.getVersion().contains("devBuild"))
 			{
 				
-				if ( ("devBuild-" + Citizens.getLatestBuildVersion()) != Citizens.getVersion() ) {
+				if ( !("devBuild-" + Citizens.getLatestBuildVersion()).equals(Citizens.getVersion()) ) {
 					Messaging.send(player, null, ChatColor.YELLOW + "**ALERT** "
 							+ ChatColor.GREEN
 							+ "There is a new development version of Citizens available!");
 					return;
 				}
 			} else {
-				if ( Citizens.getLatestVersion() != Citizens.getVersion() ) {
+				if ( !Citizens.getLatestVersion().equals(Citizens.getVersion()) ) {
 					Messaging.send(player, null, ChatColor.YELLOW + "**ALERT** "
 							+ ChatColor.GREEN
 							+ "There is a new version of Citizens available!");

--- a/src/core/net/citizensnpcs/utils/ServerUtils.java
+++ b/src/core/net/citizensnpcs/utils/ServerUtils.java
@@ -24,24 +24,35 @@ public class ServerUtils {
 	}
 
 	// Check the Citizens thread on the Bukkit forums if there is a new version
-	// available
+	// available, or use Citizens.getLatestBuildVersion() for devBuilds.
 	public static void checkForUpdates(Player player) {
 		try {
-			URI baseURI = new URI("http://forums.bukkit.org/threads/7173/");
-			HttpURLConnection con = (HttpURLConnection) baseURI.toURL()
-					.openConnection();
-			con.setInstanceFollowRedirects(false);
-			if (con.getHeaderField("Location") == null) {
-				Messaging
-						.log("Couldn't connect to Citizens thread to check for updates.");
-				return;
-			}
-			String url = new URI(con.getHeaderField("Location")).toString();
-			if (!url.contains(Citizens.getReleaseVersion().replace(".", "-"))) {
-				Messaging.send(player, null, ChatColor.YELLOW + "**ALERT** "
-						+ ChatColor.GREEN
-						+ "There is a new version of Citizens available!");
-				return;
+			if(Citizens.getVersion().contains("devBuild"))
+			{
+				
+				if ( ("devBuild-" + Citizens.getLatestBuildVersion()) == Citizens.getVersion() ) {
+					Messaging.send(player, null, ChatColor.YELLOW + "**ALERT** "
+							+ ChatColor.GREEN
+							+ "There is a new development version of Citizens available!");
+					return;
+				}
+			} else {
+				URI baseURI = new URI("http://forums.bukkit.org/threads/7173/");
+				HttpURLConnection con = (HttpURLConnection) baseURI.toURL()
+						.openConnection();
+				con.setInstanceFollowRedirects(false);
+				if (con.getHeaderField("Location") == null) {
+					Messaging
+							.log("Couldn't connect to Citizens thread to check for updates.");
+					return;
+				}
+				String url = new URI(con.getHeaderField("Location")).toString();
+				if (!url.contains(Citizens.getVersion().replace(".", "-"))) {
+					Messaging.send(player, null, ChatColor.YELLOW + "**ALERT** "
+							+ ChatColor.GREEN
+							+ "There is a new version of Citizens available!");
+					return;
+				}
 			}
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/src/core/net/citizensnpcs/utils/ServerUtils.java
+++ b/src/core/net/citizensnpcs/utils/ServerUtils.java
@@ -30,24 +30,14 @@ public class ServerUtils {
 			if(Citizens.getVersion().contains("devBuild"))
 			{
 				
-				if ( ("devBuild-" + Citizens.getLatestBuildVersion()) == Citizens.getVersion() ) {
+				if ( ("devBuild-" + Citizens.getLatestBuildVersion()) != Citizens.getVersion() ) {
 					Messaging.send(player, null, ChatColor.YELLOW + "**ALERT** "
 							+ ChatColor.GREEN
 							+ "There is a new development version of Citizens available!");
 					return;
 				}
 			} else {
-				URI baseURI = new URI("http://forums.bukkit.org/threads/7173/");
-				HttpURLConnection con = (HttpURLConnection) baseURI.toURL()
-						.openConnection();
-				con.setInstanceFollowRedirects(false);
-				if (con.getHeaderField("Location") == null) {
-					Messaging
-							.log("Couldn't connect to Citizens thread to check for updates.");
-					return;
-				}
-				String url = new URI(con.getHeaderField("Location")).toString();
-				if (!url.contains(Citizens.getVersion().replace(".", "-"))) {
+				if ( Citizens.getLatestVersion() != Citizens.getVersion() ) {
 					Messaging.send(player, null, ChatColor.YELLOW + "**ALERT** "
 							+ ChatColor.GREEN
 							+ "There is a new version of Citizens available!");


### PR DESCRIPTION
Reordered/redesigned build.xml to compile and package each target before moving onto the next.

Latest.php is to get the latest available devBuild, not the current one, changed this to match.

Added in a method for automatically making getVersion() display the appropriate devBuild #

Changed the update checking code so if it is a dev build, it informs of dev builds

Changed the update checking code so it checks for updates via a server-side script, so the location and way of retreiving the latest version number can be changed on new and existing builds in future.

Not sure if there was anything else that I have done, difficult to test if it works til it is implimented into the jenkins entirely, however I have used this method on the begginings of my own project, and it works correctly.
