### PR TITLE
Fixed economy being disabled on partial reloads.

### DIFF
--- a/src/core/net/citizensnpcs/listeners/ServerListen.java
+++ b/src/core/net/citizensnpcs/listeners/ServerListen.java
@@ -45,7 +45,7 @@ public class ServerListen extends ServerListener implements Listener {
 
 	@Override
 	public void onPluginDisable(PluginDisableEvent event) {
-		if (this.methods != null && Methods.hasMethod()) {
+		if (this.methods != null && Methods.getMethod().getPlugin().equals(event.getPlugin())) {
 			Economy.setServerEconomyEnabled(false);
 		}
 	}


### PR DESCRIPTION
On our server, we use plugins to only reload certain plugins. It saves time and headaches. When we started using citizens economy, however, it disabled when any plugin was reloaded. This seemed to fix it for us. (It's a very small change, but it helped us a lot)
