### PR TITLE
Fix Economy breaking when any plugin disables

### DIFF
--- a/src/core/net/citizensnpcs/listeners/ServerListen.java
+++ b/src/core/net/citizensnpcs/listeners/ServerListen.java
@@ -33,7 +33,7 @@ public class ServerListen implements Listener {
 
     @EventHandler
     public void onPluginDisable(PluginDisableEvent event) {
-        if (this.methods != null && Methods.hasMethod()) {
+        if (this.methods != null && Methods.hasMethod() && Methods.getMethod().isCompatible(event.getPlugin())) {
             Economy.setServerEconomyEnabled(false);
         }
     }


### PR DESCRIPTION
I've been maintaining a fork of citizens for a month or so now, and this is one of the changes that I made. Pulling it to master would make my job easier every update. =)
