### PR TITLE
Fix Economy breaking when any plugin disables

### DIFF
--- a/src/core/net/citizensnpcs/listeners/ServerListen.java
+++ b/src/core/net/citizensnpcs/listeners/ServerListen.java
@@ -33,7 +33,7 @@ public class ServerListen implements Listener {
 
     @EventHandler
     public void onPluginDisable(PluginDisableEvent event) {
-        if (this.methods != null && Methods.hasMethod()) {
+        if (this.methods != null && Methods.hasMethod() && Methods.getMethod().getPlugin().equals(event.getPlugin())) {
             Economy.setServerEconomyEnabled(false);
         }
     }


### PR DESCRIPTION
This should fix the issue that happens when any plugin disables - MysticRealms has this issue a lot when hot-reloading plugins using Plugin Reloader. (Of course, this fixes it)
