### PR TITLE
Issue #s: 963, 640, 946

### DIFF
--- a/src/core/net/citizensnpcs/commands/BasicCommands.java
+++ b/src/core/net/citizensnpcs/commands/BasicCommands.java
@@ -1,6 +1,7 @@
 package net.citizensnpcs.commands;
 
 import java.util.ArrayDeque;
+import java.lang.Math;
 
 import net.citizensnpcs.Citizens;
 import net.citizensnpcs.Economy;
@@ -322,7 +323,7 @@ public class BasicCommands extends CommandHandler {
             }
             double amount;
             try {
-                amount = Double.parseDouble(args.getString(2));
+                amount = Math.abs(Double.parseDouble(args.getString(2)));
             } catch (NumberFormatException e) {
                 Messaging.sendError(player, "Invalid balance change amount entered.");
                 return;

--- a/src/core/net/citizensnpcs/permissions/PermissionManager.java
+++ b/src/core/net/citizensnpcs/permissions/PermissionManager.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 public class PermissionManager {
     private static Permission provider = null;
     private static boolean permissionsEnabled;
+    private static boolean groupPermissionsEnabled;
     private static final List<String> permissions = new ArrayList<String>();
 
     public void init() {
@@ -31,6 +32,7 @@ public class PermissionManager {
             if (permissionProvider != null) {
                 provider = permissionProvider.getProvider();
                 permissionsEnabled = true;
+                groupPermissionsEnabled = true;
             }
         } catch (NoClassDefFoundError ex) {
         }
@@ -99,11 +101,21 @@ public class PermissionManager {
     }
 
     public static Set<CitizensGroup> getGroups(Player player) {
-        if (!permissionsEnabled)
+        if (!groupPermissionsEnabled)
             return null;
         Set<CitizensGroup> groups = Sets.newHashSet();
-        for (String group : provider.getPlayerGroups(player)) {
-            groups.add(new CitizensGroup(group));
+        try {
+        	for (String group : provider.getPlayerGroups(player)) {
+        		groups.add(new CitizensGroup(group));
+        	}
+        }
+        
+        // This will be thrown if permissions fails to load the group permissions.
+        // Issue # 963
+        catch (UnsupportedOperationException permissionsException){
+        	System.out.println("Disabling group permissions.\nReason: " + permissionsException.getMessage());
+        	groupPermissionsEnabled = false;
+        	return null;
         }
         return groups;
     }

--- a/src/trader/net/citizensnpcs/traders/TraderProperties.java
+++ b/src/trader/net/citizensnpcs/traders/TraderProperties.java
@@ -1,5 +1,6 @@
 package net.citizensnpcs.traders;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -8,6 +9,8 @@ import net.citizensnpcs.properties.Node;
 import net.citizensnpcs.properties.Properties;
 import net.citizensnpcs.properties.PropertyManager;
 import net.citizensnpcs.resources.npclib.HumanNPC;
+import net.citizensnpcs.Settings;
+import net.citizensnpcs.Settings.SettingsType;
 
 import org.bukkit.inventory.ItemStack;
 
@@ -107,6 +110,8 @@ public class TraderProperties extends PropertyManager implements Properties {
 
 	@Override
 	public List<Node> getNodes() {
-		return null;
+		List<Node> nodes = new ArrayList<Node>();
+		nodes.add(new Node("TraderAccessDelay", SettingsType.GENERAL, "trader.access-delay", 500));
+		return nodes;
 	}
 }


### PR DESCRIPTION
963:
- Submitting a pull request to make the error message a bit nicer.
- It should also not flood the server with Unhanded exception errors when this triggers.

640:
- Players are not longer able to use negative numbers when using /npc money.
- Instead the absolute value of the amount will be used.

946: Traders inventory can be cleared by everyone.
- Added a configurable 500ms delay to trader right click interaction.
- This prevents the trashing that was occurring where the server thought the player was no longer looking at the trader.
