### PR TITLE
Minor fix.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -38,7 +38,7 @@ commands:
         description: Performs player-quest related commands.
         usage: |
                         The command was not recognized.
-                        See /citizens help for a list of commands.
+                        See /quest help for a list of commands.
     quester:
         description: Performs various Quester NPC-related commands.
         usage: |


### PR DESCRIPTION
There IS a /quest help, so I think that /quest should redirect to that, not /citizens help.
