### PR TITLE
/quest status should say also the kind of monsters

### DIFF
--- a/src/quester/net/citizensnpcs/questers/quests/types/HuntQuest.java
+++ b/src/quester/net/citizensnpcs/questers/quests/types/HuntQuest.java
@@ -36,6 +36,6 @@ public class HuntQuest implements QuestUpdater {
 
     @Override
     public String getStatus(ObjectiveProgress progress) {
-        return QuestUtils.defaultAmountProgress(progress, "monsters killed");
+        return QuestUtils.defaultAmountProgress(progress, progress.getObjective().getString().toLowerCase()+" killed");
     }
 }


### PR DESCRIPTION
Making /quest status say also the kind of monsters you have to kill and not just 'monsters'...
