### PR TITLE
Vault doesn't like negative values.

### DIFF
--- a/src/core/net/citizensnpcs/Economy.java
+++ b/src/core/net/citizensnpcs/Economy.java
@@ -103,7 +103,10 @@ public class Economy {
     // Pays for an operation using the player's money.
     public static double pay(Player player, double price) {
         if (useEconPlugin()) {
-            subtract(player.getName(), price);
+        	if(price > 0)
+        		subtract(player.getName(), price);
+        	else
+        		add(player.getName(), -price);
             return price;
         }
         return 0;


### PR DESCRIPTION
Vault "Cannot withdraw negative funds".
(see https://github.com/MilkBowl/Vault/blob/master/src/net/milkbowl/vault/economy/plugins/Economy_iConomy6.java)

In some part of the code, you use Economy.pay with negative values (example: /npc money take).
